### PR TITLE
seems to help with issue #17

### DIFF
--- a/src/00-wsl2-systemd.sh
+++ b/src/00-wsl2-systemd.sh
@@ -14,6 +14,7 @@ SYSTEMD_PID="$(ps -C systemd -o pid= | head -n1)"
 if [ -z "$SYSTEMD_PID" ] || [ "$SYSTEMD_PID" -ne 1 ]; then
 	if [ -z "$SUDO_USER" ]; then
 		[ -f "$HOME/.systemd.env" ] && rm "$HOME/.systemd.env"
+		SUDO_USER="root"
 		export > "$HOME/.systemd.env"
 	fi
 


### PR DESCRIPTION
I met the same issue as [#17](https://github.com/diddledani/one-script-wsl2-systemd/issues/17), since my wsl is using 'root' as default user.

It's caused by 00-wsl2-systemd:94 

```bash
exec /usr/bin/nsenter --mount --pid --target "$SYSTEMD_PID" -- su - "$SUDO_USER"
```

that, variable "SUDO_USER" is empty when using root.

So I added line 17 `SUDO_USER="root"` to the file, and it seems to be working now (partially).

However, gpg-agent.sh:12 caused another issue: the `wslvar 'ProgramFiles(x86)'` useage, which is actually invalid:

![image](https://user-images.githubusercontent.com/54871796/166664906-ae344968-d29b-40d4-a3cf-144d64cc8bb1.png)

It seems that `wslvar` imports an raw `$env:ProgramFiles(x86)` usage.

What's more, I do think most people may prefer to use git's gpg (Git\usr\bin\gpg.exe)?
